### PR TITLE
!fix/feat(epochs): fix start/end times, introduce block times and active_stake

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2829,30 +2829,46 @@ components:
           type: integer
           example: 1603835086
           description: Unix time of the end of the epoch
-        blocks_count:
+        first_block_time:
+          type: integer
+          example: 1603403092
+          description: Unix time of the first block of the epoch
+        last_block_time:
+          type: integer
+          example: 1603835084
+          description: Unix time of the last block of the epoch
+        block_count:
           type: integer
           example: 21298
           description: Number of blocks within the epoch
-        txs_count:
+        tx_count:
           type: integer
           example: 17856
           description: Number of transactions within the epoch
-        txs_sum:
+        output:
           type: string
           example: "7849943934049314"
           description: Sum of all the transactions within the epoch in Lovelaces
-        fees_sum:
+        fees:
           type: string
           example: "4203312194"
           description: Sum of all the fees within the epoch in Lovelaces
+        active_stake:
+          nullable: true
+          type: string
+          example: "784953934049314"
+          description: Sum of all the active stakes within the epoch in Lovelaces
       required:
         - epoch
         - start_time
         - end_time
-        - blocks_count
-        - txs_count
-        - txs_sum
-        - fees_sum
+        - first_block_time
+        - last_block_time
+        - block_count
+        - tx_count
+        - output
+        - fees
+        - active_stake
     epoch_stake_content:
       type: array
       items:


### PR DESCRIPTION
Epochs improvements and fixes.

Improvements:
- introduced `first_block_time` and `last_block_time` which are first and last block times of the queried epoch
- introduced `active_stake` which is the sum of amount staked in queried epoch

Fixes:
- `start_time` and `end_time` times will correctly reflect epoch times (previously, first and last block times were displayed, respectively)
 
! Breaking change - unify terminology.

- `blocks_count` -> `block_count`
- `txs_count -> tx_count`
- `txs_sum` -> `output`
- `fees_sum` -> `fees`

Affected endpoints: `/epochs/latest`, `/epochs/{number}`, `/epochs/{number}/next`, `/epochs/{number}/previous`.