### PR TITLE
assets: renaming acronym to ticker

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4141,7 +4141,7 @@ components:
               nullable: true
               example: "The Nut Coin"
               description: Asset description
-            acronym:
+            ticker:
               type: string
               nullable: true
               example: "nutc"


### PR DESCRIPTION
Renaming `acronym` to `ticker` after this change has bee made in the metadata registry.