### PR TITLE
fix missing attribute error schemas.tx_metadata_label_json.items

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3762,7 +3762,6 @@ components:
               - type: string
               - type: object
               - type: number
-              - type: array
               - type: boolean
             nullable: true
             description: Content of the JSON metadata


### PR DESCRIPTION
```
Errors:
	- attribute components.schemas.tx_metadata_label_json.items is missing
```

Not sure about the impact of this on backend side.