### PR TITLE
fix(metadata): json_metadata type

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3758,9 +3758,12 @@ components:
             type: string
             description: Transaction hash that contains the specific metadata
           json_metadata:
-            oneOf:
+            anyOf:
               - type: string
               - type: object
+              - type: array
+                items: {}
+              - type: integer
               - type: number
               - type: boolean
             nullable: true


### PR DESCRIPTION
Following up on https://github.com/blockfrost/openapi/pull/10 - cc @sorki - Either this or leaving `type` completely out seems to fix the issue. We might want to keep `array` in, since it is a valid JSON. Would this work for you?

There's a further discussion on types: https://github.com/OAI/OpenAPI-Specification/issues/1657

According to https://swagger.io/docs/specification/data-models/data-types/, `AnyValue` should be equivalent to:
```
      anyOf:
        - type: string
        - type: number
        - type: integer
        - type: boolean
        - type: array
          items: {}
        - type: object
 ```