### PR TITLE
!feat(tx/submit): moving to a base64 encoded transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - unreleased
+
+### Changed
+
+- The `/tx/submit` endpoint now accepts CBOR encoded serialized transaction instread of a binary blob.
+
 ## [0.1.5] - 2021-03-12
 
 ### Added

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1204,28 +1204,25 @@ paths:
       tags:
         - Transactions
       summary: Submit a transaction
-      description: Submit a signed transaction message binary blob to the network.
+      description: Submit a base64 encoding serialized transaction to the network.
       parameters:
         - in: header
           name: Content-Type
           required: true
           schema:
             type: string
-            enum: ["application/octet-stream"]
+            enum: ["application/cbor"]
       responses:
         "200":
           description: Return the ID of the submitted transaction.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    format: hex
-                    minLength: 64
-                    maxLength: 64
-                    example: "d1662b24fa9fe985fc2dce47455df399cb2e31e1e1819339e885801cc3578908"
+                type: string
+                format: hex
+                minLength: 64
+                maxLength: 64
+                example: "d1662b24fa9fe985fc2dce47455df399cb2e31e1e1819339e885801cc3578908"
         "400":
           $ref: "#/components/responses/bad_request"
         "403":


### PR DESCRIPTION
Moving the submit of transaction to support CBOR encoded payload instead of the binary blob.