### PR TITLE
chore(docs): hex encoded values

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -40,7 +40,8 @@ info:
     * All time and timestamp related fields are in milliseconds of UNIX time.
     * All amounts are returned in Lovelaces, where 1 ADA = 1 000 000 Lovelaces.
     * Addresses, accounts and pool IDs are in Bech32 format.
-    * Hex encoded values are case sensitive. You need to use lower-case hex.
+    * All values are case sensitive.
+    * All hex encoded values are lower case.
     * Examples are not based on real data. Any resemblance to actual events is purely coincidental.
 
     ## Errors

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -38,8 +38,9 @@ info:
       * You might use the `?order=desc` query parameter to reverse this order.
     * By default, we return 100 results at a time. You have to use `?page=2` to list through the results.
     * All time and timestamp related fields are in milliseconds of UNIX time.
-    * All amounts are returned in Lovelaces, where 1 ADA = 1 000 000 Lovelaces
-    * Addresses, accounts and pool IDs are in Bech32 format
+    * All amounts are returned in Lovelaces, where 1 ADA = 1 000 000 Lovelaces.
+    * Addresses, accounts and pool IDs are in Bech32 format.
+    * Hex encoded values are case sensitive. You need to use lower-case hex.
     * Examples are not based on real data. Any resemblance to actual events is purely coincidental.
 
     ## Errors


### PR DESCRIPTION
Documenting that our API is case sensitive and we prefer lower case use for HEX. 

SDKs needs to make sure they are passing it as such.