### PR TITLE
chore(ipfs): enum the state of a pin

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2739,6 +2739,7 @@ paths:
                     description: IPFS hash of the pinned object
                   state:
                     type: string
+                    enum: [queued|pinned|unpinned|failed|gc]
                     example: "queued"
                     description: State of the pin action
         "400":
@@ -2924,6 +2925,7 @@ paths:
                     description: IPFS hash of the pinned object
                   state:
                     type: string
+                    enum: [queued|pinned|unpinned|failed|gc]
                     example: "unpinned"
                     description: State of the pin action
         "400":


### PR DESCRIPTION
Enuming the possible state of a pinned item.