### PR TITLE
feat(assets): Adding on-chain metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [] - Unreleased
 
+### Added
+
+- `onchain_metadata` to `/assets/{asset}` endpoint
+
 ### Fixed
 
 - `/pools` trailing slash in documentation

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4758,6 +4758,7 @@ components:
           description: ID of the initial minting transaction
         onchain_metadata:
           type: object
+          additionalProperties: true,
           nullable: true
           description: |
             On-chain metadata stored in the minting transaction under label 721,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4756,6 +4756,21 @@ components:
           type: string
           example: "6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad"
           description: ID of the initial minting transaction
+        onchain_metadata:
+          type: object
+          nullable: true
+          description: |
+            On-chain metadata stored in the minting transaction under label 721,
+            community discussion around the standard ongoing at https://github.com/cardano-foundation/CIPs/pull/85
+          properties:
+            name:
+              type: string
+              description: Name of the asset
+              example: My NFT token
+            image:
+              type: string
+              description: URI of the associated asset
+              example: ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226
         metadata:
           type: object
           nullable: true

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4766,11 +4766,11 @@ components:
             name:
               type: string
               description: Name of the asset
-              example: My NFT token
+              example: "My NFT token"
             image:
               type: string
               description: URI of the associated asset
-              example: ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226
+              example: "ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226"
         metadata:
           type: object
           nullable: true


### PR DESCRIPTION
There is an on-going discussion for a community on-chain standard that is already widely used at https://github.com/cardano-foundation/CIPs/pull/85

This metadata is stored under the label `721` of the minting transaction, under the policy id and token name.