### PR TITLE
Documentation improvements

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4018,6 +4018,10 @@ components:
       type: apiKey
       in: header
       name: project_id
+      description: |
+        There are multiple token types available based on network you choose
+        when creating a Blockfrost a project, for a list of token types
+        see [Available networks](#section/Available-networks)
 
   schemas:
     block_content_array:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -16,7 +16,7 @@ info:
   description: |
     Blockfrost is an API as a service that allows users to interact with the Cardano blockchain and parts of its ecosystem.
 
-    ## Authentication
+    ## Tokens
 
     After signing up on https://blockfrost.io, a `project_id` token is automatically generated for each project.
     HTTP header of your request MUST include this `project_id` in order to authenticate against Blockfrost servers.


### PR DESCRIPTION
So it's less tricky to discover when following e.g. `IPFS » Add` -> `Authorizations: ApiKeyAuth` link.


aed16e7  resolves a collision in ToC.