### PR TITLE
Fix metrics and metrics_endpoints examples ...

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6067,11 +6067,11 @@ components:
           - endpoint
       example:
         - [
-            { "date": 1612543814, "calls": 182, "endpoint": "block" },
-            { "date": 1612543814, "calls": 42, "endpoint": "epoch" },
-            { "date": 1612543812, "calls": 775, "endpoint": "block" },
-            { "date": 1612523884, "calls": 4, "endpoint": "epoch" },
-            { "date": 1612553884, "calls": 89794, "endpoint": "block" },
+            { "time": 1612543814, "calls": 182, "endpoint": "block" },
+            { "time": 1612543814, "calls": 42, "endpoint": "epoch" },
+            { "time": 1612543812, "calls": 775, "endpoint": "block" },
+            { "time": 1612523884, "calls": 4, "endpoint": "epoch" },
+            { "time": 1612553884, "calls": 89794, "endpoint": "block" },
           ]
 
     nutlink_address:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6043,8 +6043,8 @@ components:
           - calls
       example:
         - [
-            { "date": 1612543884, "calls": 42 },
-            { "date": 1614523884, "calls": 6942 },
+            { "time": 1612543884, "calls": 42 },
+            { "time": 1614523884, "calls": 6942 },
           ]
 
     metrics_endpoints:


### PR DESCRIPTION
... using `date` instead of `time`.