### PR TITLE
Couple inconsistencies discovered recently

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -127,7 +127,6 @@ paths:
     get:
       tags:
         - Health
-      security: []
       summary: Root endpoint
       description: |
         Root endpoint has no other function than to point end users to documentation.
@@ -163,7 +162,6 @@ paths:
     get:
       tags:
         - Health
-      security: []
       summary: Backend health status
       description: |
         Return backend status as a boolean. Your application
@@ -196,7 +194,6 @@ paths:
     get:
       tags:
         - Health
-      security: []
       summary: Current backend time
       description: |
         This endpoint provides the current UNIX time. Your application might

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -38,7 +38,7 @@ info:
     * Data is returned in *ascending* (oldest first, newest last) order.
       * You might use the `?order=desc` query parameter to reverse this order.
     * By default, we return 100 results at a time. You have to use `?page=2` to list through the results.
-    * All time and timestamp related fields are in milliseconds of UNIX time.
+    * All time and timestamp related fields are in seconds of UNIX time.
     * All amounts are returned in Lovelaces, where 1 ADA = 1 000 000 Lovelaces.
     * Addresses, accounts and pool IDs are in Bech32 format.
     * All values are case sensitive.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -320,7 +320,7 @@ paths:
           schema:
             type: string
             format: 64-character case-sensitive hexadecimal string or block number.
-          description: Hash of the requested block.
+          description: Hash or number of the requested block.
           example: "4ea1ba291e8eef538635a53e59fddba7810d1679631cc3aed7c8e6c4091a516a"
       responses:
         "200":
@@ -384,7 +384,7 @@ paths:
         - Cardano » Blocks
       summary: Specific block in a slot in an epoch
       description: |
-        Return the content of a requested block for a specific slot in an epoch
+        Return the content of a requested block for a specific slot in an epoch.
       parameters:
         - in: path
           name: epoch_number
@@ -1511,7 +1511,7 @@ paths:
         - Cardano » Accounts
       summary: Account reward history
       description: |
-        Obtain information about the history of a specific account.
+        Obtain information about the reward history of a specific account.
       parameters:
         - in: path
           name: stake_address

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -38,7 +38,7 @@ info:
     * Data is returned in *ascending* (oldest first, newest last) order.
       * You might use the `?order=desc` query parameter to reverse this order.
     * By default, we return 100 results at a time. You have to use `?page=2` to list through the results.
-    * All time and timestamp related fields are in seconds of UNIX time.
+    * All time and timestamp related fields (except `server_time`) are in seconds of UNIX time.
     * All amounts are returned in Lovelaces, where 1 ADA = 1 000 000 Lovelaces.
     * Addresses, accounts and pool IDs are in Bech32 format.
     * All values are case sensitive.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -795,7 +795,7 @@ paths:
       tags:
         - Cardano » Epochs
       summary: Stake distribution
-      description: Return the active stake distribution for the epoch specified.
+      description: Return the active stake distribution for the specified epoch.
       parameters:
         - in: path
           name: number


### PR DESCRIPTION
Maybe even:

 ```diff
- All time and timestamp related fields are in seconds of UNIX time.
+ All time and timestamp related fields (except `server_time`) are in seconds of UNIX time.
```