### PR TITLE
ipfs: fix ipfs/add response size type to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reaches maturity in v1.
 
+## [0.1.27] - 2021-08-xx
+
+### Fixed
+
+- `/ipfs/add` size response type fixed from integer to string
+- types of IPFS size examples
+- description of `ipfs/pin/list/<object>`
+
 ## [0.1.26] - 2021-08-12
 
 ### Fixed

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3437,6 +3437,7 @@ paths:
     get:
       tags:
         - IPFS » Pins
+      summary: List pinned objects
       description: List objects pinned to local storage
       parameters:
         - in: query

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3304,7 +3304,7 @@ paths:
     post:
       tags:
         - IPFS » Add
-      summary: Add a file or directory to IPFS
+      summary: Add a file to IPFS
       description: |
         You need to `/ipfs/pin/add` an object to avoid it being garbage collected. This usage
         is being counted in your user account quota.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3525,7 +3525,8 @@ paths:
     get:
       tags:
         - IPFS » Pins
-      description: List objects pinned to local storage
+      summary: Get details about pinned object
+      description: Get information about locally pinned IPFS object
       parameters:
         - in: path
           required: true

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3332,9 +3332,9 @@ paths:
                     example: QmZbHqiCxKEVX7QfijzJTkZiSi3WEVTcvANgNAWzDYgZDr
                     description: IPFS hash of the file
                   size:
-                    type: integer
-                    example: 125297
-                    description: Size of the file
+                    type: string
+                    example: "125297"
+                    description: IPFS node size in Bytes
                 required:
                   - name
                   - ipfs_hash

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3489,7 +3489,7 @@ paths:
                     size:
                       type: string
                       description: Size of the object in Bytes
-                      example: 1615551024
+                      example: "1615551024"
                     state:
                       type: string
                       enum: [queued|pinned|unpinned|failed|gc]
@@ -3555,7 +3555,7 @@ paths:
                   size:
                     type: string
                     description: Size of the object in Bytes
-                    example: 1615551024
+                    example: "1615551024"
                   state:
                     type: string
                     enum: [queued|pinned|unpinned|failed|gc]


### PR DESCRIPTION
https://github.com/ipfs/go-ipfs/issues/4008#issuecomment-311198782

Also the decription is changed as it returns resulting IPFS node
size according to https://github.com/ipfs/go-ipfs/pull/4082