### PR TITLE
fix(txs): add data_hash example for `txs/{hash}/utxos` inputs

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4841,6 +4841,7 @@ components:
               data_hash:
                 type: string
                 description: The hash of the transaction output datum
+                example: "9e478573ab81ea7a8e31891ce0648b81229f408d596a3483e6f4f9b92d3cf710"
                 nullable: true
               collateral:
                 type: boolean


### PR DESCRIPTION
Noticed it's a `string` instead of some hash.