### PR TITLE
Examples and type of `collateral_percent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed
 
+* `/epochs/{number}/parameters` - `collateral_percent` type from `number` to `integer`
+
 ### Fixed
 
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4699,7 +4699,7 @@ components:
           description: The maximum Val size
         collateral_percent:
           nullable: true
-          type: number
+          type: integer
           example: 150
           description: The percentage of the transactions fee which must be provided as collateral when including non-native scripts
         max_collateral_inputs:


### PR DESCRIPTION
I've noticed that `collateral_percent` is 150 and its type is `uint` not a `float` so changing this one to prevent confusion.