### PR TITLE
fix: account info active_epoch can be null

### DIFF
--- a/src/schemas/accounts/account_content.yaml
+++ b/src/schemas/accounts/account_content.yaml
@@ -10,6 +10,7 @@ properties:
     description: Registration state of an account
   active_epoch:
     type: integer
+    nullable: true
     example: 412
     description: Epoch of the most recent action - registration or deregistration
   controlled_amount:


### PR DESCRIPTION
Via https://github.com/blockfrost/blockfrost-haskell/issues/16