### PR TITLE
Use `stake_address` in path in total.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2255,7 +2255,7 @@ paths:
         account.
       parameters:
         - in: path
-          name: address
+          name: stake_address
           required: true
           schema:
             type: string

--- a/src/paths/api/accounts/{stake_address}/addresses/total.yaml
+++ b/src/paths/api/accounts/{stake_address}/addresses/total.yaml
@@ -7,7 +7,7 @@ get:
     <b>Be careful</b>, as an account could be part of a mangled address and does not necessarily mean the addresses are owned by user as the account.
   parameters:
     - in: path
-      name: address
+      name: stake_address
       required: true
       schema:
         type: string


### PR DESCRIPTION
The spec published here https://docs.blockfrost.io/ seems to throw some errors:
https://github.com/ozerogames/openapi/blob/master/openapi.yaml#L2258
vs
https://github.com/ozerogames/openapi/blob/master/openapi.yaml#L2244

This PR might fix it, idk, maybe, probably.


 - [ ] Tested