### PR TITLE
Remove unused path element, specify array item type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4671,12 +4671,6 @@ paths:
           schema:
             type: string
             description: Address of a metadata oracle
-        - in: path
-          required: true
-          name: ticker
-          schema:
-            type: string
-            description: Ticker for the pool record
         - in: query
           name: count
           required: false
@@ -7267,6 +7261,8 @@ components:
               oneOf:
                 - type: string
                 - type: array
+                  items:
+                    type: string
               description: URI(s) of the associated asset
               example: ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226
         metadata:

--- a/src/paths/api/nutlink/{address}/tickers/index.yaml
+++ b/src/paths/api/nutlink/{address}/tickers/index.yaml
@@ -9,12 +9,6 @@ get:
       schema:
         type: string
         description: Address of a metadata oracle
-    - in: path
-      required: true
-      name: ticker
-      schema:
-        type: string
-        description: Ticker for the pool record
     - in: query
       name: count
       required: false

--- a/src/schemas/assets/asset.yaml
+++ b/src/schemas/assets/asset.yaml
@@ -45,6 +45,8 @@ properties:
         oneOf:
           - type: string
           - type: array
+            items:
+              type: string
         description: URI(s) of the associated asset
         example: "ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226"
   metadata:


### PR DESCRIPTION
1. extra in-path element reported by swagger editor `https://editor.swagger.io/`

2. missing `items` for type array reported by OpenAPI Tools

```sh
> docker run --rm openapitools/openapi-generator-cli validate -i https://raw.githubusercontent.com/blockfrost/openapi/master/openapi.yaml
Validating spec (https://raw.githubusercontent.com/blockfrost/openapi/master/openapi.yaml)
Errors:
	- attribute components.schemas.asset.items is missing
```