### PR TITLE
Fix `/pools/extended` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 
 - `getSchemaForEndpoint` util function
 
+### Fixed
+
+- `/pools/extended` example
+
 ## [0.1.43] - 2022-08-25
 
 - skipped due to acciedental npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ typescript types are now exported by default
     - `coins_per_utxo_size` is now
       - Cost per UTxO **word** for Alonzo.
       - Cost per UTxO **byte** for Babbage and later.
-- `/scripts/{hash}`
+- `/scripts/{hash}` ⚠️
   - `type` field now uses `plutusV1` and `plutusV2` instead of just `plutus` to be able
     to differentiate between two `PlutusScript` versions.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7471,12 +7471,15 @@ components:
           - live_stake
       example:
         - pool_id: pool19u64770wqp6s95gkajc8udheske5e6ljmpq33awxk326zjaza0q
+          hex: 2f355f79ee007502d116ecb07e36f985b34cebf2d84118f5c6b455a1
           active_stake: '1541200000'
           live_stake: '1541400000'
         - pool_id: pool1dvla4zq98hpvacv20snndupjrqhuc79zl6gjap565nku6et5zdx
+          hex: 6b3fda88053dc2cee18a7c2736f032182fcc78a2fe912e869aa4edcd
           active_stake: '22200000'
           live_stake: '48955550'
         - pool_id: pool1wvccajt4eugjtf3k0ja3exjqdj7t8egsujwhcw4tzj4rzsxzw5w
+          hex: 73318ec975cf1125a6367cbb1c9a406cbcb3e510e49d7c3aab14aa31
           active_stake: '9989541215'
           live_stake: '168445464878'
     pool_list_retire:

--- a/src/schemas/pools/pool_list_extended.yaml
+++ b/src/schemas/pools/pool_list_extended.yaml
@@ -25,11 +25,14 @@ items:
     - live_stake
 example:
   - pool_id: "pool19u64770wqp6s95gkajc8udheske5e6ljmpq33awxk326zjaza0q"
+    hex: "2f355f79ee007502d116ecb07e36f985b34cebf2d84118f5c6b455a1"
     active_stake: "1541200000"
     live_stake: "1541400000"
   - pool_id: "pool1dvla4zq98hpvacv20snndupjrqhuc79zl6gjap565nku6et5zdx"
+    hex: "6b3fda88053dc2cee18a7c2736f032182fcc78a2fe912e869aa4edcd"
     active_stake: "22200000"
     live_stake: "48955550"
   - pool_id: "pool1wvccajt4eugjtf3k0ja3exjqdj7t8egsujwhcw4tzj4rzsxzw5w"
+    hex: "73318ec975cf1125a6367cbb1c9a406cbcb3e510e49d7c3aab14aa31"
     active_stake: "9989541215"
     live_stake: "168445464878"


### PR DESCRIPTION
missing `hex`.

Also add warning emoji to the only incompatible change of last HF.