### PR TITLE
chore: cip68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unreleased changes are in the `master` branch.
 
 ## [0.1.x] - Unreleased
 
+## Added
+
+- `validateCIP68Metadata` util function to validate CIP68 metadata
+
 ## [0.1.50] - 2022-12-13
 
 ## Added

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5228,6 +5228,10 @@ components:
   schemas:
     onchain_metadata_cip25:
       $ref: '#/components/schemas/asset_onchain_metadata_cip25'
+    onchain_metadata_cip68_ft_333:
+      $ref: '#/components/schemas/asset_onchain_metadata_cip68_ft_333'
+    onchain_metadata_cip68_nft_222:
+      $ref: '#/components/schemas/asset_onchain_metadata_cip68_nft_222'
     block_content:
       type: object
       properties:
@@ -8576,6 +8580,87 @@ components:
             - type: array
               items:
                 type: string
+          description: Additional description
+          example: My NFT token description
+        mediaType:
+          type: string
+          description: Mime sub-type of image
+          example: image/jpeg
+        files:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+            properties:
+              name:
+                type: string
+                description: Name of the file
+                example: myimage
+              mediaType:
+                type: string
+                description: Mime sub-type of image
+                example: image/jpeg
+              src:
+                oneOf:
+                  - type: string
+                  - type: array
+                    items:
+                      type: string
+                description: URI pointing to a resource of this mime type
+                example: My NFT token description
+            required:
+              - mediaType
+              - src
+      required:
+        - name
+        - image
+    asset_onchain_metadata_cip68_ft_333:
+      type: object
+      additionalProperties: true
+      description: |
+        On-chain metadata stored in the datum of the reference NFT output
+        which adheres to 333 FT Standard https://cips.cardano.org/cips/cip68/
+      properties:
+        name:
+          type: string
+          description: Name of the asset
+          example: My FT token
+        description:
+          type: string
+          description: Additional description
+          example: My FT token description
+        logo:
+          type: string
+          description: URI(s) of the associated asset
+          example: ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226
+        ticker:
+          type: string
+          description: Ticker
+          example: TOK
+        decimals:
+          type: number
+          description: Number of decimals
+          example: 8
+      required:
+        - name
+        - description
+    asset_onchain_metadata_cip68_nft_222:
+      type: object
+      additionalProperties: true
+      description: |
+        On-chain metadata stored in the datum of the reference NFT output
+        which adheres to 222 NFT Standard https://cips.cardano.org/cips/cip68/
+      properties:
+        name:
+          type: string
+          description: Name of the asset
+          example: My NFT token
+        image:
+          type: string
+          description: URI(s) of the associated asset
+          example: ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226
+        description:
+          type: string
           description: Additional description
           example: My NFT token description
         mediaType:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockfrost/openapi",
-  "version": "0.1.50",
+  "version": "0.1.51-beta.1",
   "description": "OpenAPI specifications for blockfrost.io",
   "repository": "git@github.com:blockfrost/openapi.git",
   "author": "admin@blockfrost.io",

--- a/src/definitions.yaml
+++ b/src/definitions.yaml
@@ -573,6 +573,10 @@ components:
   schemas:
     onchain_metadata_cip25:
       $ref: ./schemas/assets/asset_onchain_metadata_cip25.yaml
+    onchain_metadata_cip68_ft_333:
+      $ref: ./schemas/assets/asset_onchain_metadata_cip68_ft_333.yaml
+    onchain_metadata_cip68_nft_222:
+      $ref: ./schemas/assets/asset_onchain_metadata_cip68_nft_222.yaml
 
   responses:
     overusage_limit:

--- a/src/functions/metadata.ts
+++ b/src/functions/metadata.ts
@@ -87,3 +87,29 @@ export const getOnchainMetadata = (
     validCIPversion,
   };
 };
+
+export const validateCIP68Metadata = (
+  input: { metadata: unknown; version: number } | null,
+  schema: 'ft' | 'nft',
+): { version: 'CIP68v1' } | false => {
+  if (!input) return false;
+  if (input.version !== 1) return false;
+
+  if (schema === 'nft') {
+    const { isValid: isValidNFT } = validateSchema(
+      'asset_onchain_metadata_cip68_nft_222',
+      input.metadata,
+    );
+
+    return isValidNFT ? { version: 'CIP68v1' } : false;
+  } else if (schema === 'ft') {
+    const { isValid: isValidFT } = validateSchema(
+      'asset_onchain_metadata_cip68_ft_333',
+      input.metadata,
+    );
+
+    return isValidFT ? { version: 'CIP68v1' } : false;
+  } else {
+    return false;
+  }
+};

--- a/src/generated-types.ts
+++ b/src/generated-types.ts
@@ -2985,6 +2985,8 @@ export interface paths {
 export interface components {
   schemas: {
     onchain_metadata_cip25: components["schemas"]["asset_onchain_metadata_cip25"];
+    onchain_metadata_cip68_ft_333: components["schemas"]["asset_onchain_metadata_cip68_ft_333"];
+    onchain_metadata_cip68_nft_222: components["schemas"]["asset_onchain_metadata_cip68_nft_222"];
     block_content: {
       /**
        * @description Block creation time in UNIX time
@@ -5904,6 +5906,80 @@ export interface components {
        * @example My NFT token description
        */
       description?: string | string[];
+      /**
+       * @description Mime sub-type of image
+       * @example image/jpeg
+       */
+      mediaType?: string;
+      files?: ({
+        /**
+         * @description Name of the file
+         * @example myimage
+         */
+        name?: string;
+        /**
+         * @description Mime sub-type of image
+         * @example image/jpeg
+         */
+        mediaType: string;
+        /**
+         * @description URI pointing to a resource of this mime type
+         * @example My NFT token description
+         */
+        src: string | string[];
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
+    /**
+     * @description On-chain metadata stored in the datum of the reference NFT output
+     * which adheres to 333 FT Standard https://cips.cardano.org/cips/cip68/
+     */
+    asset_onchain_metadata_cip68_ft_333: {
+      /**
+       * @description Name of the asset
+       * @example My FT token
+       */
+      name: string;
+      /**
+       * @description Additional description
+       * @example My FT token description
+       */
+      description: string;
+      /**
+       * @description URI(s) of the associated asset
+       * @example ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226
+       */
+      logo?: string;
+      /**
+       * @description Ticker
+       * @example TOK
+       */
+      ticker?: string;
+      /**
+       * @description Number of decimals
+       * @example 8
+       */
+      decimals?: number;
+    } & { [key: string]: unknown };
+    /**
+     * @description On-chain metadata stored in the datum of the reference NFT output
+     * which adheres to 222 NFT Standard https://cips.cardano.org/cips/cip68/
+     */
+    asset_onchain_metadata_cip68_nft_222: {
+      /**
+       * @description Name of the asset
+       * @example My NFT token
+       */
+      name: string;
+      /**
+       * @description URI(s) of the associated asset
+       * @example ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226
+       */
+      image: string;
+      /**
+       * @description Additional description
+       * @example My NFT token description
+       */
+      description?: string;
       /**
        * @description Mime sub-type of image
        * @example image/jpeg

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   getOnchainMetadata,
   getOnchainMetadataVersion,
   getCIPstandard,
+  validateCIP68Metadata,
 } from './functions/metadata';
 
 export {
@@ -16,6 +17,7 @@ export {
   getOnchainMetadata,
   getCIPstandard,
   getOnchainMetadataVersion,
+  validateCIP68Metadata,
 };
 
 export type { paths, components } from './generated-types';

--- a/src/schemas/assets/asset_onchain_metadata_cip68_ft_333.yaml
+++ b/src/schemas/assets/asset_onchain_metadata_cip68_ft_333.yaml
@@ -1,0 +1,29 @@
+type: object
+additionalProperties: true
+description: |
+  On-chain metadata stored in the datum of the reference NFT output
+  which adheres to 333 FT Standard https://cips.cardano.org/cips/cip68/
+properties:
+  name:
+    type: string
+    description: Name of the asset
+    example: "My FT token"
+  description:
+    type: string
+    description: Additional description
+    example: My FT token description
+  logo:
+    type: string
+    description: URI(s) of the associated asset
+    example: "ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226"
+  ticker:
+    type: string
+    description: Ticker
+    example: TOK
+  decimals:
+    type: number
+    description: Number of decimals
+    example: 8
+required:
+  - name
+  - description

--- a/src/schemas/assets/asset_onchain_metadata_cip68_nft_222.yaml
+++ b/src/schemas/assets/asset_onchain_metadata_cip68_nft_222.yaml
@@ -1,0 +1,50 @@
+type: object
+additionalProperties: true
+description: |
+  On-chain metadata stored in the datum of the reference NFT output
+  which adheres to 222 NFT Standard https://cips.cardano.org/cips/cip68/
+properties:
+  name:
+    type: string
+    description: Name of the asset
+    example: "My NFT token"
+  image:
+    type: string
+    description: URI(s) of the associated asset
+    example: "ipfs://ipfs/QmfKyJ4tuvHowwKQCbCHj4L5T3fSj8cjs7Aau8V7BWv226"
+  description:
+    type: string
+    description: Additional description
+    example: My NFT token description
+  mediaType:
+    type: string
+    description: Mime sub-type of image
+    example: image/jpeg
+  files:
+    type: array
+    items:
+      type: object
+      additionalProperties: true
+      properties:
+        name:
+          type: string
+          description: Name of the file
+          example: myimage
+        mediaType:
+          type: string
+          description: Mime sub-type of image
+          example: image/jpeg
+        src:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: URI pointing to a resource of this mime type
+          example: My NFT token description
+      required:
+        - mediaType
+        - src
+required:
+  - name
+  - image

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -9,5 +9,6 @@ export type GetOnchainMetadataResult = {
 };
 
 export type CIPTypes = 'CIP25v1' | 'CIP25v2' | null;
+export type CIP68Version = 'CIP68v1' | null;
 
 export type { Schemas, Asset };

--- a/test/fixtures/metadata.ts
+++ b/test/fixtures/metadata.ts
@@ -439,3 +439,123 @@ export const parseOnChainMetadataFixtures = [
     },
   },
 ];
+
+export const validateCIP68Metadata = [
+  {
+    name: 'Matrix Berry #99 (NFT metadata)',
+    payload: {
+      metadata: {
+        description: '',
+        id: 99,
+        image: 'ipfs://QmYNyQbwLCYvjP743Jnud1bozcFPDSXFyYNYUmfQjYs5AQ',
+        name: 'Matrix Berry #99',
+        additionalFields: 'thisWontBreakValidation',
+      },
+      version: 1,
+    },
+    standard: 'nft',
+    response: {
+      version: 'CIP68v1',
+    },
+  },
+  {
+    name: 'Unsupported metadata version fails validation',
+    payload: {
+      metadata: {
+        description: '',
+        image: 'ipfs://QmYNyQbwLCYvjP743Jnud1bozcFPDSXFyYNYUmfQjYs5AQ',
+        name: 'Matrix Berry #99',
+      },
+      version: 2,
+    },
+    standard: 'nft',
+    response: false,
+  },
+  {
+    name: 'non-number version fails validation',
+    payload: {
+      metadata: {
+        description: '',
+        image: 'ipfs://QmYNyQbwLCYvjP743Jnud1bozcFPDSXFyYNYUmfQjYs5AQ',
+        name: 'Matrix Berry #99',
+      },
+      version: 'nan',
+    },
+    standard: 'nft',
+    response: false,
+  },
+  {
+    name: 'null metadata papyload',
+    payload: null,
+    standard: 'nft',
+    response: false,
+  },
+  {
+    name: 'FT with invalid ticker',
+    payload: {
+      metadata: {
+        description: 'test',
+        name: 'test asset',
+        ticker: 58008,
+        additionalFields: 'thisWontBreakValidation',
+      },
+      version: 1,
+    },
+    standard: 'ft',
+    response: false,
+  },
+  {
+    name: 'invalid standard',
+    payload: {
+      metadata: {
+        description: '',
+        id: 99,
+        image: 'ipfs://QmYNyQbwLCYvjP743Jnud1bozcFPDSXFyYNYUmfQjYs5AQ',
+        name: 'Matrix Berry #99',
+        additionalFields: 'thisWontBreakValidation',
+      },
+      version: 1,
+    },
+    standard: 'not-valid',
+    response: false,
+  },
+  {
+    name: 'Bison Coin (invalid NFT due to missing image prop)',
+    payload: {
+      metadata: {
+        name: 'Bison Coin',
+        files: [
+          {
+            src: 'ipfs://QmPk6SY8P4yWekK1Z9BSrLfQ8bPDHZiirWVgi5hdsyvnvd',
+            name: 'BISON',
+            mediaType: 'image/png',
+          },
+        ],
+      },
+      version: 1,
+    },
+    standard: 'nft',
+    response: false,
+  },
+  {
+    name: 'Bison Coin (valid FT)',
+    payload: {
+      metadata: {
+        name: 'Bison Coin',
+        description: 'desc',
+        files: [
+          {
+            src: 'ipfs://QmPk6SY8P4yWekK1Z9BSrLfQ8bPDHZiirWVgi5hdsyvnvd',
+            name: 'BISON',
+            mediaType: 'image/png',
+          },
+        ],
+      },
+      version: 1,
+    },
+    standard: 'ft',
+    response: {
+      version: 'CIP68v1',
+    },
+  },
+];

--- a/test/tests/metadata.test.ts
+++ b/test/tests/metadata.test.ts
@@ -20,4 +20,15 @@ describe('metadata functions', () => {
   expect(lib.getCIPstandard(1, true)).toStrictEqual('CIP25v1');
   expect(lib.getCIPstandard(2, true)).toStrictEqual('CIP25v2');
   expect(lib.getCIPstandard(3, false)).toStrictEqual(null);
+
+  fixtures.validateCIP68Metadata.map(fixture => {
+    test(fixture.name, () => {
+      const result = lib.validateCIP68Metadata(
+        fixture.payload,
+        fixture.standard as 'ft' | 'nft',
+      );
+
+      expect(result).toStrictEqual(fixture.response);
+    });
+  });
 });


### PR DESCRIPTION
few things I am not sure about:
- [CIP68 specifies description field within metadata for the NFT standard](https://cips.cardano.org/cips/cip68/#metadata) as ``` ? description : bounded_bytes, ; UTF-8```, but [CIP25 also allows an array](https://cips.cardano.org/cips/cip25/#generalstructure). Right now array won't pass the validation. ✅ 
- what about (future) CIP68 metadata with version > 1? Currently version other than 1 won't pass the validation. ✅  (discussed)
- Should additional fields within the metadata that are not defined in CIP25 (or off-chain metadata standard) fail the validation? Currently they will pass. ✅  (CIP25 allows additional fields)
- Regarding implementation in RYO: If CIP68 metadata (extracted from datum) are present, but fail the validation. Should they be returned anyway or in such a case it will fallback to regular onchain metadata? ✅   (discussed, should not matter as both should never be defined)