### PR TITLE
deprecate min_utxo, add note about eras (/epochs/{number}/parameters,…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Unreleased changes are in the `master` branch.
 
 ## [Unreleased]
 
+### Changed
+
+- `/epochs/{number}/parameters` and `/epochs/latest/parameters`
+  - `min_utxo` field deprecated, prefer `coins_per_utxo_size` for Alonzo and later eras
+
 ## [0.1.62] - 2024-03-05
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -7643,7 +7643,8 @@
           "min_utxo": {
             "type": "string",
             "example": "1000000",
-            "description": "Minimum UTXO value"
+            "description": "Minimum UTXO value. Use `coins_per_utxo_size` for Alonzo and later eras",
+            "deprecated": true
           },
           "min_pool_cost": {
             "type": "string",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5625,7 +5625,8 @@ components:
         min_utxo:
           type: string
           example: '1000000'
-          description: Minimum UTXO value
+          description: Minimum UTXO value. Use `coins_per_utxo_size` for Alonzo and later eras
+          deprecated: true
         min_pool_cost:
           type: string
           example: '340000000'

--- a/src/generated-types.ts
+++ b/src/generated-types.ts
@@ -3991,7 +3991,8 @@ export interface components {
        */
       protocol_minor_ver: number;
       /**
-       * @description Minimum UTXO value
+       * @deprecated
+       * @description Minimum UTXO value. Use `coins_per_utxo_size` for Alonzo and later eras
        * @example 1000000
        */
       min_utxo: string;

--- a/src/schemas/epochs/epoch_param_content.yaml
+++ b/src/schemas/epochs/epoch_param_content.yaml
@@ -72,7 +72,8 @@ properties:
   min_utxo:
     type: "string"
     example: "1000000"
-    description: Minimum UTXO value
+    description: Minimum UTXO value. Use `coins_per_utxo_size` for Alonzo and later eras
+    deprecated: true
   min_pool_cost:
     type: string
     example: "340000000"

--- a/test/tests/__snapshots__/get-schema-for-endpoint.test.ts.snap
+++ b/test/tests/__snapshots__/get-schema-for-endpoint.test.ts.snap
@@ -7948,7 +7948,8 @@ under which it is valid
             "type": "string",
           },
           "min_utxo": {
-            "description": "Minimum UTXO value",
+            "deprecated": true,
+            "description": "Minimum UTXO value. Use \`coins_per_utxo_size\` for Alonzo and later eras",
             "example": "1000000",
             "type": "string",
           },
@@ -9124,7 +9125,8 @@ under which it is valid
             "type": "string",
           },
           "min_utxo": {
-            "description": "Minimum UTXO value",
+            "deprecated": true,
+            "description": "Minimum UTXO value. Use \`coins_per_utxo_size\` for Alonzo and later eras",
             "example": "1000000",
             "type": "string",
           },


### PR DESCRIPTION
… /epochs/latest/parameters)

close https://github.com/blockfrost/openapi/issues/346