### PR TITLE
Fix: IPFS examples

### DIFF
--- a/blockfrost-openapi.yaml
+++ b/blockfrost-openapi.yaml
@@ -5349,14 +5349,6 @@ paths:
         <p>
           <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
         </p>
-      x-codeSamples:
-        - lang: Shell
-          label: cURL
-          source: |
-            curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
-              -X POST \
-              -H "project_id: $PROJECT_ID" \
-              -F "file=@./README.md"
       requestBody:
         content:
           multipart/form-data:
@@ -5366,6 +5358,14 @@ paths:
                 file:
                   type: string
                   format: binary
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
+              -X POST \
+              -H "project_id: $PROJECT_ID" \
+              -F "file=@./README.md"
       responses:
         '200':
           description: Returns information about added IPFS object
@@ -5415,6 +5415,12 @@ paths:
         <p>
           <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
         </p>
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/gateway/{IPFS_path}" \
+              -H "project_id: $PROJECT_ID" \
       parameters:
         - in: path
           required: true
@@ -5457,6 +5463,12 @@ paths:
           schema:
             type: string
             description: Path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/add/{IPFS_path}" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns pinned object
@@ -5540,6 +5552,12 @@ paths:
           description: |
             The ordering of items from the point of view of the blockchain,
             not the page listing itself. By default, we return oldest first, newest last.
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns pinned objects
@@ -5618,6 +5636,12 @@ paths:
           schema:
             type: string
             description: The path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/{IPFS_PATH}" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns the pins pinned
@@ -5695,6 +5719,13 @@ paths:
           schema:
             type: string
             description: The path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/remove/{IPFS_PATH}" \
+              -X POST \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns the pins removed

--- a/docs/blockfrost-openapi.yaml
+++ b/docs/blockfrost-openapi.yaml
@@ -5600,14 +5600,6 @@ paths:
         <p>
           <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
         </p>
-      x-codeSamples:
-        - lang: Shell
-          label: cURL
-          source: |
-            curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
-              -X POST \
-              -H "project_id: $PROJECT_ID" \
-              -F "file=@./README.md"
       requestBody:
         content:
           multipart/form-data:
@@ -5617,6 +5609,14 @@ paths:
                 file:
                   type: string
                   format: binary
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
+              -X POST \
+              -H "project_id: $PROJECT_ID" \
+              -F "file=@./README.md"
       responses:
         '200':
           description: Returns information about added IPFS object
@@ -5668,6 +5668,12 @@ paths:
         <p>
           <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
         </p>
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/gateway/{IPFS_path}" \
+              -H "project_id: $PROJECT_ID" \
       parameters:
         - in: path
           required: true
@@ -5713,6 +5719,12 @@ paths:
           schema:
             type: string
             description: Path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/add/{IPFS_path}" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns pinned object
@@ -5798,6 +5810,12 @@ paths:
 
             not the page listing itself. By default, we return oldest first,
             newest last.
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns pinned objects
@@ -5883,6 +5901,12 @@ paths:
           schema:
             type: string
             description: The path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/{IPFS_PATH}" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns the pins pinned
@@ -5971,6 +5995,14 @@ paths:
           schema:
             type: string
             description: The path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: >
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/remove/{IPFS_PATH}"
+            \
+              -X POST \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns the pins removed

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5600,14 +5600,6 @@ paths:
         <p>
           <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
         </p>
-      x-codeSamples:
-        - lang: Shell
-          label: cURL
-          source: |
-            curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
-              -X POST \
-              -H "project_id: $PROJECT_ID" \
-              -F "file=@./README.md"
       requestBody:
         content:
           multipart/form-data:
@@ -5617,6 +5609,14 @@ paths:
                 file:
                   type: string
                   format: binary
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
+              -X POST \
+              -H "project_id: $PROJECT_ID" \
+              -F "file=@./README.md"
       responses:
         '200':
           description: Returns information about added IPFS object
@@ -5668,6 +5668,12 @@ paths:
         <p>
           <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
         </p>
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/gateway/{IPFS_path}" \
+              -H "project_id: $PROJECT_ID" \
       parameters:
         - in: path
           required: true
@@ -5713,6 +5719,12 @@ paths:
           schema:
             type: string
             description: Path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/add/{IPFS_path}" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns pinned object
@@ -5798,6 +5810,12 @@ paths:
 
             not the page listing itself. By default, we return oldest first,
             newest last.
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns pinned objects
@@ -5883,6 +5901,12 @@ paths:
           schema:
             type: string
             description: The path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: |
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/{IPFS_PATH}" \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns the pins pinned
@@ -5971,6 +5995,14 @@ paths:
           schema:
             type: string
             description: The path to the IPFS object
+      x-codeSamples:
+        - lang: Shell
+          label: cURL
+          source: >
+            curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/remove/{IPFS_PATH}"
+            \
+              -X POST \
+              -H "project_id: $PROJECT_ID" \
       responses:
         '200':
           description: Returns the pins removed

--- a/src/paths/ipfs/add.yaml
+++ b/src/paths/ipfs/add.yaml
@@ -12,14 +12,6 @@ post:
     <p>
       <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
     </p>
-  x-codeSamples:
-    - lang: "Shell"
-      label: "cURL"
-      source: |
-        curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
-          -X POST \
-          -H "project_id: $PROJECT_ID" \
-          -F "file=@./README.md"
   requestBody:
     content:
       multipart/form-data:
@@ -29,6 +21,14 @@ post:
             file:
               type: string
               format: binary
+  x-codeSamples:
+    - lang: "Shell"
+      label: "cURL"
+      source: |
+        curl "https://ipfs.blockfrost.io/api/v0/ipfs/add" \
+          -X POST \
+          -H "project_id: $PROJECT_ID" \
+          -F "file=@./README.md"
   responses:
     "200":
       description: Returns information about added IPFS object

--- a/src/paths/ipfs/gateway/{IPFS_path}/index.yaml
+++ b/src/paths/ipfs/gateway/{IPFS_path}/index.yaml
@@ -10,6 +10,12 @@ get:
     <p>
       <span class="hosted">Hosted</span> Endpoint only available for hosted variant.
     </p>
+  x-codeSamples:
+    - lang: "Shell"
+      label: "cURL"
+      source: |
+        curl "https://ipfs.blockfrost.io/api/v0/ipfs/gateway/{IPFS_path}" \
+          -H "project_id: $PROJECT_ID" \
   parameters:
     - in: path
       required: true

--- a/src/paths/ipfs/pin/add/{IPFS_path}/index.yaml
+++ b/src/paths/ipfs/pin/add/{IPFS_path}/index.yaml
@@ -12,6 +12,12 @@ post:
       schema:
         type: string
         description: Path to the IPFS object
+  x-codeSamples:
+    - lang: "Shell"
+      label: "cURL"
+      source: |
+        curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/add/{IPFS_path}" \
+          -H "project_id: $PROJECT_ID" \
   responses:
     "200":
       description: Returns pinned object

--- a/src/paths/ipfs/pin/list/index.yaml
+++ b/src/paths/ipfs/pin/list/index.yaml
@@ -39,6 +39,12 @@ get:
       description: |
         The ordering of items from the point of view of the blockchain,
         not the page listing itself. By default, we return oldest first, newest last.
+  x-codeSamples:
+    - lang: "Shell"
+      label: "cURL"
+      source: |
+        curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/" \
+          -H "project_id: $PROJECT_ID" \
   responses:
     "200":
       description: Returns pinned objects

--- a/src/paths/ipfs/pin/list/{IPFS_path}/index.yaml
+++ b/src/paths/ipfs/pin/list/{IPFS_path}/index.yaml
@@ -17,6 +17,12 @@ get:
       schema:
         type: string
         description: The path to the IPFS object
+  x-codeSamples:
+    - lang: "Shell"
+      label: "cURL"
+      source: |
+        curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/list/{IPFS_PATH}" \
+          -H "project_id: $PROJECT_ID" \
   responses:
     "200":
       description: Returns the pins pinned

--- a/src/paths/ipfs/pin/remove/{IPFS_path}/index.yaml
+++ b/src/paths/ipfs/pin/remove/{IPFS_path}/index.yaml
@@ -17,6 +17,13 @@ post:
       schema:
         type: string
         description: The path to the IPFS object
+  x-codeSamples:
+    - lang: "Shell"
+      label: "cURL"
+      source: |
+        curl "https://ipfs.blockfrost.io/api/v0/ipfs/pin/remove/{IPFS_PATH}" \
+          -X POST \
+          -H "project_id: $PROJECT_ID" \
   responses:
     "200":
       description: Returns the pins removed


### PR DESCRIPTION
### What

I believe
- because no `x-codeSamples` are provided for the IPFS endpoints (except `POST /ipfs/add`)
- then the site generated usage examples shown via https://docs.blockfrost.io/ default to showing the wrong path 
  - Shown is `https://cardano-mainnet.blockfrost.io`,  the correct path is `https://ipfs.blockfrost.io/api/v0/ipfs`.
- this is not the case for `POST /ipfs/add` because an example `x-codeSamples` is given.

<img width="1118" alt="Screenshot 2024-11-18 at 21 54 51" src="https://github.com/user-attachments/assets/001265df-1f17-48cc-b098-cedd183e8e69">

### Changes

- I have added a `x-codeSamples` example for each IPFS endpoint, with the correct base path (`https://ipfs.blockfrost.io/api/v0/ipfs`)

### Why

- Incorrect examples being given by defualt can be confusing for people trying to use the IPFS endpoints
  - I was stuck for an embarrassing amount of time...

### Notes

- This might not be the best way to fix this, as this only fixes the issue for the `cURL` example.
- Draft because I haven't been able to run an instance of the hosted website, to double check that this is correct - im not familiar with rust so im unsure
