### PR TITLE
Reopening Token Metadata fix 

### DIFF
--- a/src/functions/metadata.ts
+++ b/src/functions/metadata.ts
@@ -147,20 +147,19 @@ export const getOnchainMetadata = (
         onchainMetadataCbor,
       );
       const foundMetadata = foundAssetInCbor
-        ? internalOnchainMetadata[policyIdVersion2][assetNameVersion2] 
+        ? internalOnchainMetadata[policyIdVersion2][assetNameVersion2]
         : null;
       if (foundMetadata) {
         onchainMetadataResult = foundMetadata;
         isFound = true;
       } else {
-        
         const foundHexStringMetadata = foundAssetInCbor
-          ? internalOnchainMetadata[assetNameBase][policyId] 
+          ? internalOnchainMetadata[policyId][assetNameBase] 
           : null;
-          if (foundHexStringMetadata) {
-            onchainMetadataResult = foundHexStringMetadata;
-            isFound = true;
-          }else{
+        if (foundHexStringMetadata) {
+          onchainMetadataResult = foundHexStringMetadata;
+          isFound = true;
+        }else{
             // Fallback
             // Due to previously missing and then incorrect implementation, metadata submitted as v2
             // (i.e. "version" field encoded in CBOR was set to 2) with mistakenly text-encoded

--- a/src/functions/metadata.ts
+++ b/src/functions/metadata.ts
@@ -147,23 +147,32 @@ export const getOnchainMetadata = (
         onchainMetadataCbor,
       );
       const foundMetadata = foundAssetInCbor
-        ? internalOnchainMetadata[policyIdVersion2][assetNameVersion2]
+        ? internalOnchainMetadata[policyIdVersion2][assetNameVersion2] 
         : null;
       if (foundMetadata) {
         onchainMetadataResult = foundMetadata;
         isFound = true;
       } else {
-        // Fallback
-        // Due to previously missing and then incorrect implementation, metadata submitted as v2
-        // (i.e. "version" field encoded in CBOR was set to 2) with mistakenly text-encoded
-        // policies/asset names (which is CIP25v1 method of encoding) instead of correct CIP25v2
-        // byte-encoded keys passed as valid. (Note that the version number is a user input
-        // independent of the actual metadata content).
-        // To prevent breaking change, in case we don't find metadata for an asset under
-        // correct byte-encoded key, we fallback to CIP25v1 text-encoded format.
-        onchainMetadataResult =
-          internalOnchainMetadata[policyId][assetNameVersion1] || null;
-        isFound = false;
+        
+        const foundHexStringMetadata = foundAssetInCbor
+          ? internalOnchainMetadata[assetNameBase][policyId] 
+          : null;
+          if (foundHexStringMetadata) {
+            onchainMetadataResult = foundHexStringMetadata;
+            isFound = true;
+          }else{
+            // Fallback
+            // Due to previously missing and then incorrect implementation, metadata submitted as v2
+            // (i.e. "version" field encoded in CBOR was set to 2) with mistakenly text-encoded
+            // policies/asset names (which is CIP25v1 method of encoding) instead of correct CIP25v2
+            // byte-encoded keys passed as valid. (Note that the version number is a user input
+            // independent of the actual metadata content).
+            // To prevent breaking change, in case we don't find metadata for an asset under
+            // correct byte-encoded key, we fallback to CIP25v1 text-encoded format.
+            onchainMetadataResult =
+              internalOnchainMetadata[policyId][assetNameVersion1] || null;
+            isFound = false;
+        }
       }
     } catch (error) {
       onchainMetadataResult = null;


### PR DESCRIPTION
After over a year, all other major indexers wallets and explorers are accepting this format. 

Tools like Lucid evolution do not even allow encoding labels in the metadata as byte arrays, please reconsider merging this fix, it is just one extra layer of fallback before giving up and registering null tokenMetadata 
