### PR TITLE
feat: serve dashboard-api docs at /dashboard-api/

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Feel free to open PR against the `master` branch. It is a great place to start a
 
 When you push a new commit, the documentation for your branch is automatically generated on Vercel and added to your PR as a deployment.
 
+### Dashboard API docs
+
+The Blockfrost **Dashboard API** documentation at
+[`docs.blockfrost.io/dashboard-api/`](https://docs.blockfrost.io/dashboard-api/)
+is **not** built from this repo. Its OpenAPI spec and Scalar build live
+separately and deploy as their own Vercel project. This repo only owns the
+`docs.blockfrost.io` host and reverse-proxies `/dashboard-api/*` to that
+project via a `rewrites` rule in [`vercel.json`](vercel.json) — each service's
+spec and build pipeline stays in its own repo.
+
 ## Usage
 
 You can download [`openapi.yaml`](openapi.yaml) directly from the repository or use this project as a dependency in your JavaScript/TypeScript project.

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,21 @@
       "source": "/midnight",
       "destination": "/midnight/",
       "permanent": true
+    },
+    {
+      "source": "/dashboard-api",
+      "destination": "/dashboard-api/",
+      "permanent": true
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/dashboard-api/",
+      "destination": "https://blockfrost-dashboard-api-docs.vercel.app/"
+    },
+    {
+      "source": "/dashboard-api/:path*",
+      "destination": "https://blockfrost-dashboard-api-docs.vercel.app/:path*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Vercel **rewrite** routing `docs.blockfrost.io/dashboard-api/*` → the standalone Vercel project that hosts the Blockfrost Dashboard API documentation. The spec and Scalar build live separately and deploy independently; this PR makes the openapi project host the path under the shared `docs.blockfrost.io` domain.
- Adds an explicit rewrite for the trailing-slash index `/dashboard-api/`, because Vercel's path matcher treats `:path*` as *one-or-more* in practice — without it, the bare index returns 404.
- Adds a 308 **redirect** from the bare `/dashboard-api` → `/dashboard-api/`, mirroring the existing `/midnight` pattern.
- README: a short note under Development describing the architecture.

## Why
Avoids copy-pasting the dashboard-api spec into this repo each release. Each service owns its spec and its Scalar build; this repo just owns the host.

## Test plan
- [x] Preview: `/dashboard-api/` renders Scalar docs after the index-path fix
- [ ] After merge + deploy:
  - `curl -I https://docs.blockfrost.io/dashboard-api/` → 200
  - `curl -I https://docs.blockfrost.io/dashboard-api` → 308 → `/dashboard-api/`
  - `curl -I https://docs.blockfrost.io/dashboard-api/openapi.yaml` → 200
- [ ] Existing routes unaffected: `/midnight/`, `/` (main openapi docs)

## Notes
- This project predates 2026-04-06, so [external rewrites aren't CDN-cached by default](https://vercel.com/docs/edge-network/rewrites#caching-rewrites-to-external-origins). That's fine for docs; if we later want CDN caching, add an `x-vercel-enable-rewrite-caching: 1` header for the `/dashboard-api/:path*` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)