### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@blockfrost/openapi",
   "version": "0.1.89",
   "description": "OpenAPI specifications for blockfrost.io",
+  "license": "MIT",
   "repository": "git@github.com:blockfrost/openapi.git",
   "author": "admin@blockfrost.io",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary
- add the MIT license field to the npm package manifest
- align package metadata with the repository LICENSE file

## Verification
- npm pack --dry-run --ignore-scripts --json
- node package manifest assertion