### PR TITLE
docs: document how to regenerate types, add dockerized rust generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ Edit the source yaml files and build the package:
 yarn build
 ```
 
+### Regenerating types
+
+TypeScript types ([`src/generated-types.ts`](src/generated-types.ts)) are regenerated as part of `yarn build`, or standalone with:
+
+```console
+yarn generate-types
+```
+
+Rust types (the [`rust/`](rust/) crate) are generated from the bundled [`openapi.yaml`](openapi.yaml), so run `yarn build` (or at least `yarn bundle`) first if you have changed the source yaml files. The generation uses [openapi-generator](https://github.com/OpenAPITools/openapi-generator), which requires a Java runtime:
+
+```console
+yarn generate-types:rust
+```
+
+If you don't have Java installed, use the Docker variant, which runs the same generator version inside a container:
+
+```console
+yarn generate-types:rust:docker
+```
+
+The generator version is pinned in [`openapitools.json`](openapitools.json) — when bumping it, update the image tag in the `generate-types:rust:docker` script to match.
+
+> Note that the Rust generation emits models only (`apis=false`), so spec changes that only touch endpoints or query parameters produce no changes in the crate.
+
 ### Midnight GraphQL docs
 
 The Midnight Indexer GraphQL API documentation is generated using [SpectaQL](https://github.com/anvilco/spectaql) from the schema file [`midnight-indexer-api.graphql`](midnight-indexer-api.graphql). The SpectaQL configuration is in [`spectaql.yaml`](spectaql.yaml) and the custom theme is in [`spectaql-theme/`](spectaql-theme/).

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:midnight-docs": "yarn spectaql ./spectaql.yaml && cp ./midnight-indexer-api.graphql ./docs/midnight/midnight-indexer-api.graphql",
     "generate-types": "yarn openapi-typescript ./openapi.yaml --output ./src/generated-types.ts",
     "generate-types:rust": "rimraf ./rust/src/models && openapi-generator-cli generate -i openapi.yaml -g rust -o ./rust -c rust/openapi-generator.json -t rust/templates --global-property models,modelDocs=false,apis=false,apiDocs=false,supportingFiles && node rust/fix-cargo.js",
+    "generate-types:rust:docker": "rimraf ./rust/src/models && docker run --rm -v \"$PWD:/local\" openapitools/openapi-generator-cli:v7.20.0 generate -i /local/openapi.yaml -g rust -o /local/rust -c /local/rust/openapi-generator.json -t /local/rust/templates --global-property models,modelDocs=false,apis=false,apiDocs=false,supportingFiles && node rust/fix-cargo.js",
     "generate-json-schema": "node lib/scripts/generate-json-schema.js > json-schema.json",
     "sync-version": "ts-node ./src/scripts/sync-version.ts",
     "test": "vitest",


### PR DESCRIPTION
## Summary

- Adds a `generate-types:rust:docker` script that runs the **same pinned openapi-generator version** (`v7.20.0`, from `openapitools.json`) via the official Docker image — no local Java runtime needed.
- Documents the type regeneration workflow (TypeScript + Rust) in a new *Regenerating types* section of the README, including the note that the Rust crate is models-only (`apis=false`), so endpoint/query-parameter-only spec changes produce no crate diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)